### PR TITLE
chore: harden GitHub Actions controls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,11 @@ jobs:
   check:
     name: Check
     runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && (github.event_name != 'push' || !contains(github.event.head_commit.message, '[skip ci]'))
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # pin action
         with:
           toolchain: stable
@@ -33,9 +35,11 @@ jobs:
   fmt:
     name: Format
     runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && (github.event_name != 'push' || !contains(github.event.head_commit.message, '[skip ci]'))
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # pin action
         with:
           toolchain: stable
@@ -45,9 +49,11 @@ jobs:
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && (github.event_name != 'push' || !contains(github.event.head_commit.message, '[skip ci]'))
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # pin action
         with:
           toolchain: stable
@@ -58,9 +64,11 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && (github.event_name != 'push' || !contains(github.event.head_commit.message, '[skip ci]'))
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # pin action
         with:
           toolchain: stable
@@ -70,11 +78,13 @@ jobs:
   coverage:
     name: Coverage
     runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && (github.event_name != 'push' || !contains(github.event.head_commit.message, '[skip ci]'))
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # pin action
         with:
           toolchain: stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,7 @@ jobs:
     name: Create Tag
     needs: checks
     runs-on: ubuntu-latest
+    environment: production
     permissions:
       contents: write
     outputs:
@@ -249,6 +250,7 @@ jobs:
     needs: [create-tag, build]
     if: failure() && needs.create-tag.result == 'success'
     runs-on: ubuntu-latest
+    environment: production
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
## Summary
- skip PR-triggered CI jobs when the pull request comes from a fork
- avoid persisting checkout credentials in CI jobs
- require the protected `production` environment before release tag creation and cleanup jobs can write repository contents

## Verification
- Parsed workflow YAML locally
- Ran `git diff --check`