### PR TITLE
fix: ignore promotional badges when extracting product images

### DIFF
--- a/src/api/scraper.rs
+++ b/src/api/scraper.rs
@@ -46,7 +46,7 @@ fn extract_total_count(document: &Html) -> u32 {
 
 fn extract_products(document: &Html) -> Vec<SearchProduct> {
     let tile_selector = Selector::parse("[data-product-tile-impression]").expect("valid selector");
-    let img_selector = Selector::parse("img[data-src]").expect("valid selector");
+    let img_selector = Selector::parse("img.ct-tile-image[data-src]").expect("valid selector");
     let unit_price_selector =
         Selector::parse(".pwc-tile--price-secondary").expect("valid selector");
 

--- a/tests/scraper_branches_test.rs
+++ b/tests/scraper_branches_test.rs
@@ -96,12 +96,14 @@ fn parse_search_results_handles_invalid_total_and_mixed_tiles() {
             <div
               data-product-tile-impression="{&quot;id&quot;:&quot;6879912&quot;,&quot;name&quot;:&quot;Leite UHT Meio Gordo Continente&quot;,&quot;price&quot;:0.86,&quot;brand&quot;:&quot;Continente&quot;,&quot;category&quot;:&quot;Laticínios e Ovos/Leite/Leite Meio Gordo&quot;,&quot;variant&quot;:&quot;&quot;,&quot;channel&quot;:&quot;&quot;}"
             >
-              <img data-src="https://example.com/tile.jpg" />
+              <img class="ct-tile-image" data-src="https://example.com/tile.jpg" />
               <span class="pwc-tile--price-secondary">0,86€/lt</span>
             </div>
             <div
               data-product-tile-impression="{&quot;id&quot;:&quot;2210946&quot;,&quot;name&quot;:&quot;Leite UHT Meio Gordo Mimosa&quot;,&quot;price&quot;:0.90,&quot;brand&quot;:&quot;Mimosa&quot;,&quot;category&quot;:&quot;Laticínios e Ovos/Leite/Leite Meio Gordo&quot;,&quot;variant&quot;:&quot;&quot;,&quot;channel&quot;:&quot;&quot;}"
-            ></div>
+            >
+              <img class="promo-badge" data-src="https://example.com/badge.png" />
+            </div>
           </body>
         </html>
     "#;


### PR DESCRIPTION
## Summary
- restrict search result image extraction to product tile images
- avoid treating promotional badge images as product images
- add a regression case for tiles that contain only a badge image

## Validation
- cargo test
- all active tests pass; network-dependent tests remain ignored as before